### PR TITLE
Add a command to show errors without re-running phpcs.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -6,5 +6,9 @@
     {
         "caption": "PHP CodeSniffer: Clear Sniffer Marks",
         "command": "phpcs_clear_sniffer_marks"
+    },
+    {
+        "caption": "PHP CodeSniffer: Show Previous Errors",
+        "command": "phpcs_show_previous_errors"
     }
 ]


### PR DESCRIPTION
I've add a command to allow the last-parsed errors to be re-displayed without having to re-run phpcs. Useful for large scripts which take time to be validated. 

Based on current master.
