### PR TITLE
Make the phpcs tests optional in a setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ You can configure:
 * phpcs_execute_on_save - Do you want the code sniffer plugin to run on file save for php files?
 * phpcs_show_gutter_marks - Do you want the errors to be displayed in the gutter?
 * phpcs_show_quick_panel - Do you want the errors to be displayed in the quick panel?
-* phpcs_linter_run - Do you want the PHP linter to run?
+* phpcs_sniffer_run - Do you want the PHPCS cheker to run?
+* phpcs_linter_run - Do you want the PHP linter (syntax errors) to run?
 * phpcs_linter_regex - The regex for the PHP linter output
 * phpcs_executable_path - The path to the phpcs executable. If empty string, use PATH to find it
 * phpcs_show_errors_on_save - Do you want the errors to be displayed in quick_panel on save?

--- a/phpcs.py
+++ b/phpcs.py
@@ -23,6 +23,7 @@ class Pref:
         Pref.phpcs_show_gutter_marks = bool(settings.get('phpcs_show_gutter_marks'))
         Pref.phpcs_show_errors_in_status = bool(settings.get('phpcs_show_errors_in_status'))
         Pref.phpcs_show_quick_panel = bool(settings.get('phpcs_show_quick_panel'))
+        Pref.phpcs_sniffer_run = bool(settings.get('phpcs_sniffer_run'))
         Pref.phpcs_linter_run = bool(settings.get('phpcs_linter_run'))
         Pref.phpcs_linter_regex = settings.get('phpcs_linter_regex')
         Pref.phpcs_executable_path = settings.get('phpcs_executable_path', '')
@@ -42,6 +43,7 @@ Pref.load()
     'phpcs_show_gutter_marks',
     'phpcs_show_errors_in_status',
     'phpcs_show_quick_panel',
+    'phpcs_sniffer_run',
     'phpcs_linter_run',
     'phpcs_linter_regex',
     'phpcs_executable_path',
@@ -109,6 +111,9 @@ class ShellCommand():
 class Sniffer(ShellCommand):
     """Concrete class for PHP_CodeSniffer"""
     def execute(self, path):
+        if Pref.phpcs_sniffer_run != True:
+            return
+
         if Pref.phpcs_executable_path != "":
             args = [Pref.phpcs_executable_path]
         else:

--- a/phpcs.sublime-settings
+++ b/phpcs.sublime-settings
@@ -6,6 +6,9 @@
     // execute for
     "extensions_to_execute": ["php"],
 
+    // Do you want to run the phpcs checker?
+    "phpcs_sniffer_run": false,
+
     // It seems python/sublime cannot always find the php application
     // If empty, then use PATH version of php, else use the set value
     "phpcs_php_path": "",


### PR DESCRIPTION
Somebody (at least myself :) wants to be able to run only syntax check on the PHP code.
