### PR TITLE
Update docs to point to Phpcs package name instead of PHP CodeSniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin adds PHP CodeSniffer, PHP Coding Standards Fixer, the PHP Linter and
 Installation
 ------------
 
-Use Sublime Text 2's [Package Control](http://wbond.net/sublime_packages/package_control) (Preferences -> Package Control -> Install Package -> PHP CodeSniffer) to install this plugin.
+Use Sublime Text 2's [Package Control](http://wbond.net/sublime_packages/package_control) (Preferences -> Package Control -> Install Package -> Phpcs) to install this plugin.
 
 Or
 


### PR DESCRIPTION
I was unable to install PHP CodeSniffer by way of Package Control because it would not find any variation of "PHP CodeSniffer" or "CodeSniffer" or the likes. I finally tried to install by way of git and noticed that the package is named Phpcs there and looked in Package Control and sure enough — searching for Phpcs finds the package.

It is possible that this is a st2 version difference? If so I can maybe add the original text in addition to this text so that people can know it might show up as more than one name.
