### PR TITLE
Reload settings when switching between projects

### DIFF
--- a/phpcs.py
+++ b/phpcs.py
@@ -674,3 +674,6 @@ class PhpcsEventListener(sublime_plugin.EventListener):
         cmd = PhpcsCommand.instance(view, False)
         if isinstance(cmd, PhpcsCommand):
             cmd.set_status_bar()
+
+    def on_project_load(self, window):
+        pref.load()


### PR DESCRIPTION
When switching projects I've realized that the plugin won't reload the project specific settings (different coding standards for different projects) so I've added just an event listener to initiate that, seems to work well now.

(I think I made an issue also...honestly the first time I'm contributing to something on Github so please excuse the confusion)
