### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can also configure the plugin to fix the issues using either
 
 Requirements for this plugin, should you want all the options to work:
 
-- [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)  3.5+
+- [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)  3.5+
 - [PHPMD](https://phpmd.org) 2.8+
 - [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) 2.6+
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932